### PR TITLE
Update VNC passwd create & parse commands for Debian Bookworm compatibility

### DIFF
--- a/application/features/VNC.py
+++ b/application/features/VNC.py
@@ -18,15 +18,14 @@
 #   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 #   IN THE SOFTWARE.
 
+import logging
 import os
 import re
-import logging
 import threading
 
 from .Connection import Connection
 from .mywebsockify import MyProxyRequestHandler, MySSLProxyServer
-from .vncpasswd import decrypt_passwd, obfuscate_password
-from ..resources.xstartup import XSTARTUP_STR
+from .vncpasswd import decrypt_passwd
 from ..utils import find_free_port
 
 logger = logging.getLogger(__name__)
@@ -117,7 +116,6 @@ class VNC(Connection):
             "echo '%s'| vncpasswd -f > ~/.vnc/passwd" % password,
             "chmod 600 ~/.vnc/passwd",
         ]
-        logger.debug(f"reset_cmd_lst={reset_cmd_lst}")
         _, _, _, stderr = self.exec_command_blocking(';'.join(reset_cmd_lst))
         error_lines = []
         for line in stderr:

--- a/application/features/VNC.py
+++ b/application/features/VNC.py
@@ -68,10 +68,8 @@ class VNC(Connection):
         return super().connect(*args, **kwargs)
 
     def get_vnc_password(self):
-        # return True, "123456"
         _, _, stdout, _ = self.exec_command_blocking("hexdump --format '16/1 \"%02x\"' ~/.vnc/passwd")
         hexdump = stdout.readline().rstrip()
-        logger.info(f"hexdump = {hexdump}")
         if hexdump == '':
             return False, ''
         else:
@@ -101,8 +99,6 @@ class VNC(Connection):
         return True, ''
 
     def reset_vnc_password(self, password):
-        # hexed_passwd = obfuscate_password(password).hex()
-
         reset_cmd_lst = [
             # killall -q: don't complain if no process found
             #         -w: wait until the processes to die then continue to the next cmd
@@ -137,7 +133,6 @@ class VNC(Connection):
         return True, ''
 
     def launch_vnc(self):
-        logger.debug("launch_vnc")
         ports_by_me = []
         _, _, stdout, _ = self.exec_command_blocking('vncserver -list')
         for line in stdout:

--- a/application/features/VNC.py
+++ b/application/features/VNC.py
@@ -20,6 +20,7 @@
 
 import os
 import re
+import logging
 import threading
 
 from .Connection import Connection
@@ -27,6 +28,8 @@ from .mywebsockify import MyProxyRequestHandler, MySSLProxyServer
 from .vncpasswd import decrypt_passwd, obfuscate_password
 from ..resources.xstartup import XSTARTUP_STR
 from ..utils import find_free_port
+
+logger = logging.getLogger(__name__)
 
 
 def websocket_proxy_thread(local_websocket_port, local_vnc_port):
@@ -65,8 +68,10 @@ class VNC(Connection):
         return super().connect(*args, **kwargs)
 
     def get_vnc_password(self):
-        _, _, stdout, _ = self.exec_command_blocking('xxd -p ~/.vnc/passwd')
-        hexdump = stdout.readline()
+        # return True, "123456"
+        _, _, stdout, _ = self.exec_command_blocking("hexdump --format '16/1 \"%02x\"' ~/.vnc/passwd")
+        hexdump = stdout.readline().rstrip()
+        logger.info(f"hexdump = {hexdump}")
         if hexdump == '':
             return False, ''
         else:
@@ -96,7 +101,7 @@ class VNC(Connection):
         return True, ''
 
     def reset_vnc_password(self, password):
-        hexed_passwd = obfuscate_password(password).hex()
+        # hexed_passwd = obfuscate_password(password).hex()
 
         reset_cmd_lst = [
             # killall -q: don't complain if no process found
@@ -108,16 +113,20 @@ class VNC(Connection):
             "rm -rf ~/.vnc",
             "mkdir ~/.vnc",
 
-            f"printf '{XSTARTUP_STR}' > ~/.vnc/xstartup",
-            "cp /etc/vnc/xstartup ~/.vnc  >& /dev/null",
-            "chmod 700 ~/.vnc/xstartup",
+            # FIXME: re-enable xstartup config
+            # f"printf '{XSTARTUP_STR}' > ~/.vnc/xstartup",
+            # "cp /etc/vnc/xstartup ~/.vnc  >& /dev/null",
+            # "chmod 700 ~/.vnc/xstartup",
 
-            "echo '%s'| xxd -r -p > ~/.vnc/passwd" % hexed_passwd,
+            "echo '%s'| vncpasswd -f > ~/.vnc/passwd" % password,
             "chmod 600 ~/.vnc/passwd",
         ]
+        logger.debug(f"reset_cmd_lst={reset_cmd_lst}")
         _, _, _, stderr = self.exec_command_blocking(';'.join(reset_cmd_lst))
         error_lines = []
         for line in stderr:
+            logger.error("reset_vnc_password::exec_command_blocking stderr line: %s", line)
+
             if "Disk quota exceeded" in line:
                 return False, 'Disk quota exceeded'
             else:
@@ -128,6 +137,7 @@ class VNC(Connection):
         return True, ''
 
     def launch_vnc(self):
+        logger.debug("launch_vnc")
         ports_by_me = []
         _, _, stdout, _ = self.exec_command_blocking('vncserver -list')
         for line in stdout:

--- a/application/routes/vnc.py
+++ b/application/routes/vnc.py
@@ -26,7 +26,8 @@ from .common import create_connection
 from .. import api, app, profiles
 from ..codes import ICtrlStep, ICtrlError, ConnectionType
 from ..utils import int_to_bytes
-
+import logging
+logger = logging.getLogger(__name__)
 
 @api.route('/vnc', methods=['POST'])
 def start_vnc():
@@ -97,15 +98,19 @@ def start_vnc():
 
 @api.route('/vncpasswd', methods=['POST'])
 def change_vncpasswd():
+    logger.debug("in route /vncpasswd")
     session_id = request.json.get('session_id')
 
     vnc, reason = create_connection(session_id, ConnectionType.VNC)
     if reason != '':
+        logger.error("create_connection() failed with status=", status)
         abort(403, description=reason)
 
     passwd = request.json.get('passwd')
     status, reason = vnc.reset_vnc_password(passwd)
+
     if not status:
+        logger.error("reset_vnc_password() failed with status=%s", reason)
         abort(403, description=reason)
 
     return 'success'

--- a/application/routes/vnc.py
+++ b/application/routes/vnc.py
@@ -98,7 +98,6 @@ def start_vnc():
 
 @api.route('/vncpasswd', methods=['POST'])
 def change_vncpasswd():
-    logger.debug("in route /vncpasswd")
     session_id = request.json.get('session_id')
 
     vnc, reason = create_connection(session_id, ConnectionType.VNC)

--- a/application/routes/vnc.py
+++ b/application/routes/vnc.py
@@ -19,6 +19,7 @@
 #   IN THE SOFTWARE.
 
 import json
+import logging
 
 from flask import request, abort, stream_with_context
 
@@ -26,8 +27,9 @@ from .common import create_connection
 from .. import api, app, profiles
 from ..codes import ICtrlStep, ICtrlError, ConnectionType
 from ..utils import int_to_bytes
-import logging
+
 logger = logging.getLogger(__name__)
+
 
 @api.route('/vnc', methods=['POST'])
 def start_vnc():


### PR DESCRIPTION
The list of commands that iCtrl uses to renew passwords for the UG machines at UofT contains a command called xxd(search up on Google for the purpose). However, due to a system upgrade for the UG machines, this command is no longer available which means a password renewal would not work. This PR fixes the issue and patches the bug.