### PR TITLE
Update noVNC import paths due to package structure changes.

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -10,7 +10,7 @@
     "@mui/lab": "^5.0.0-alpha.114",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@novnc/novnc": "^1.4.0",
+    "@novnc/novnc": "^1.5.0",
     "axios": "^1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/client/src/actions/vnc.js
+++ b/client/src/actions/vnc.js
@@ -21,9 +21,9 @@
  */
 
 import {ICtrlError, ICtrlStep} from './codes';
-import RFB from '@novnc/novnc/core/rfb';
-import KeyTable from '@novnc/novnc/core/input/keysym';
-import keysyms from '@novnc/novnc/core/input/keysymdef';
+import RFB from '@novnc/novnc/lib/rfb';
+import KeyTable from '@novnc/novnc/lib/input/keysym';
+import keysyms from '@novnc/novnc/lib/input/keysymdef';
 import {
   SSHAuthenticationWrong,
   SSHHostUnreachableRefresh,

--- a/client/src/interface/pages/VNCViewer/VNCSpeedDial.js
+++ b/client/src/interface/pages/VNCViewer/VNCSpeedDial.js
@@ -57,7 +57,7 @@ import './index.css';
 import {focusOnKeyboard} from '../../../actions/vnc';
 import axios from 'axios';
 import {launch_audio} from '../../../actions/audio';
-import RFB from '@novnc/novnc/core/rfb';
+import RFB from '@novnc/novnc/lib/rfb';
 import {IOSSwitch} from '../../components/IOSSwitch';
 import ResetVNCDialog from '../../components/ResetVNCDialog';
 

--- a/client/src/interface/pages/VNCViewer/index.js
+++ b/client/src/interface/pages/VNCViewer/index.js
@@ -29,7 +29,7 @@ import {VNCSteps} from '../../components/Loading/steps';
 import VNCSpeedDial from './VNCSpeedDial';
 import {focusOnKeyboard, vncConnect} from '../../../actions/vnc';
 import Toolbar from '../../components/Toolbar';
-import KeyTable from '@novnc/novnc/core/input/keysym';
+import KeyTable from '@novnc/novnc/lib/input/keysym';
 import {isIOS} from '../../../actions/utils';
 import {updateTitleAndIcon} from '../../../actions/common';
 import BackgroundLetterAvatar from '../../components/BackgroundLetterAvatar';


### PR DESCRIPTION
The original path used to import `@novnc/novnc` libraries on the client side were through the path `node_modules/@novnc/novnc/core` as those files were available in the location until 1.4.0.

There is a package structure change in `@novnc/novnc` where files are no longer available under `node_modules/@novnc/novnc/core`; instead, the files are solely available under `node_modules/@novnc/novnc/lib`. When we run `npm install` in `<iCtrl-root>/client`, npm dependency resolution decides that 1.5.0 should be installed instead of 1.4.0, which causes our source imports to break.

To address the issue, this PR:
1. Upgrade `@novnc/novnc` version to `^1.5.0` to ensure the dependency is also 1.5.0 or above when our iCtrl/client project is initiated with other package managers (e.g., `pnpm`).
2. Update import paths in iCtrl/client source files to reflect the path changes.